### PR TITLE
Qtype refactor

### DIFF
--- a/includes/qcodo/_core/framework/QDatabaseBase.class.php
+++ b/includes/qcodo/_core/framework/QDatabaseBase.class.php
@@ -196,9 +196,9 @@
 									$objDebugBacktrace[$intIndex]['args'][$intInnerIndex] = sprintf("[%s]", $objDebugBacktrace[$intIndex]['args'][$intInnerIndex]->__toString());
 								else if (is_null($objDebugBacktrace[$intIndex]['args'][$intInnerIndex]))
 									$objDebugBacktrace[$intIndex]['args'][$intInnerIndex] = 'null';
-								else if (gettype($objDebugBacktrace[$intIndex]['args'][$intInnerIndex]) == 'integer')
+								else if (QType::GetType ($objDebugBacktrace[$intIndex]['args'][$intInnerIndex]) == QType::Integer)
 									$objDebugBacktrace[$intIndex]['args'][$intInnerIndex] = $objDebugBacktrace[$intIndex]['args'][$intInnerIndex];
-								else if (gettype($objDebugBacktrace[$intIndex]['args'][$intInnerIndex]) == 'object')
+								else if (QType::GetType($objDebugBacktrace[$intIndex]['args'][$intInnerIndex]) == QType::Object)
 									$objDebugBacktrace[$intIndex]['args'][$intInnerIndex] = 'Object';
 								else
 									$objDebugBacktrace[$intIndex]['args'][$intInnerIndex] = sprintf("'%s'", $objDebugBacktrace[$intIndex]['args'][$intInnerIndex]);

--- a/includes/qcodo/_core/framework/QQuery.class.php
+++ b/includes/qcodo/_core/framework/QQuery.class.php
@@ -991,9 +991,6 @@
 		}
 
 		static public function Expand($objNode, QQCondition $objJoinCondition = null) {
-//			if (gettype($objNode) == 'string')
-//				return new QQExpandVirtualNode(new QQVirtualNode($objNode));
-
 			if ($objNode instanceof QQVirtualNode)
 				return new QQExpandVirtualNode($objNode);
 			else

--- a/includes/qcodo/_core/framework/QType.class.php
+++ b/includes/qcodo/_core/framework/QType.class.php
@@ -87,7 +87,7 @@
 		 * @param mixed $mixItem
 		 * @return string
 		 */
-		private static function GetType($mixItem){
+		public static function GetType($mixItem){
 			if (is_null($mixItem)){
 				return null;
 			} else if (is_string($mixItem)) {
@@ -158,7 +158,7 @@
 				case QType::Integer:
 					if (is_integer($mixItem))
 						return $mixItem;
-					if (!is_numeric($mixItem) && !is_bool($mixItem)){
+					if (!is_numeric($mixItem) && !is_bool($mixItem) && $mixItem != ''){
 						throw new QInvalidCastException(sprintf('Unable to cast %s value to %s', QType::GetType($mixItem), $strType));
 					}
 					if (is_bool($mixItem)){
@@ -178,7 +178,7 @@
 				case QType::Float:
 					if (is_double($mixItem))
 						return $mixItem;
-					if (!is_numeric($mixItem) && !is_bool($mixItem)){
+					if (!is_numeric($mixItem) && !is_bool($mixItem) && $mixItem != ''){
 						throw new QInvalidCastException(sprintf('Unable to cast %s value to %s', QType::GetType($mixItem), $strType));
 					}
 					if (is_bool($mixItem)){

--- a/includes/qcodo/_core/framework/_functions.inc.php
+++ b/includes/qcodo/_core/framework/_functions.inc.php
@@ -17,7 +17,7 @@
 		 */
 		function _p($strString, $blnHtmlEntities = true) {
 			// Standard Print
-			if ($blnHtmlEntities && (gettype($strString) != 'object'))
+			if ($blnHtmlEntities && (QType::GetType($strString) != QType::Object))
 				print(QApplication::HtmlEntities($strString));
 			else
 				print($strString);
@@ -35,7 +35,7 @@
 		 */
 		function _b($strString, $blnHtmlEntities = true) {
 			// Text Block Print
-			if ($blnHtmlEntities && (gettype($strString) != 'object'))
+			if ($blnHtmlEntities && (QType::GetType($strString) != QType::Object))
 				print(nl2br(QApplication::HtmlEntities($strString)));
 			else
 				print(nl2br($strString));

--- a/includes/qcodo/_core/qform/QControlBase.class.php
+++ b/includes/qcodo/_core/qform/QControlBase.class.php
@@ -690,7 +690,7 @@
 
 			// Apply any overrides (if applicable)
 			if (count($mixParameterArray) > 0) {
-				if (gettype($mixParameterArray[0]) != QType::String) {
+				if (QType::GetType($mixParameterArray[0]) != QType::String) {
 					// Pop the first item off the array
 					$mixParameterArray = array_reverse($mixParameterArray);
 					array_pop($mixParameterArray);

--- a/includes/qcodo/_core/qform/QListControl.class.php
+++ b/includes/qcodo/_core/qform/QListControl.class.php
@@ -64,7 +64,7 @@
 		 */
 		public function AddItem($mixListItemOrName, $strValue = null, $blnSelected = null, $strItemGroup = null, $strOverrideParameters = null) {
 			$this->blnModified = true;
-			if (gettype($mixListItemOrName) == QType::Object)
+			if (QType::GetType($mixListItemOrName) == QType::Object)
 				$objListItem = QType::Cast($mixListItemOrName, "QListItem");
 			elseif ($strOverrideParameters)			
 				// The OverrideParameters can only be included if they are not null, because OverrideAttributes in QBaseClass can't except a NULL Value

--- a/includes/qcodo/_core/qform/_actions.inc.php
+++ b/includes/qcodo/_core/qform/_actions.inc.php
@@ -132,7 +132,7 @@
 
 		public function RenderScript(QControl $objControl) {
 			$strWaitIconControlId = null;
-			if ((gettype($this->objWaitIconControl) == 'string') && ($this->objWaitIconControl == 'default')) {
+			if ((QType::GetType($this->objWaitIconControl) == QType::String) && ($this->objWaitIconControl == 'default')) {
 				if ($objControl->Form->DefaultWaitIcon)
 					$strWaitIconControlId = $objControl->Form->DefaultWaitIcon->ControlId;
 			} else if ($this->objWaitIconControl) {

--- a/tests/_core/QTypeTest.php
+++ b/tests/_core/QTypeTest.php
@@ -66,6 +66,12 @@
 			$this->assertType(PHPUnit_Framework_Constraint_IsType::TYPE_BOOL, $blnResult);
 			$this->assertFalse($blnResult);
 		}
+		
+		public function testEmptyStringToInteger() {
+			$intResult = QType::Cast('', QType::Integer);
+			$this->assertType(PHPUnit_Framework_Constraint_IsType::TYPE_INT, $intResult);
+			$this->assertEquals(0, $intResult);
+		}		
 
 		public function testStringToBoolean() {
 			$blnResult = QType::Cast('qcodo', QType::Boolean);


### PR DESCRIPTION
Refactored QType class to not use gettype as it's unreliable.
QType now passes all tests succesfully.
See: http://ar2.php.net/manual/en/function.gettype.php
