### PR TITLE
Changing drafts to use the new _require_prepend.inc.php file

### DIFF
--- a/includes/qcodo/_core/codegen/templates/db_orm/drafts/_qform_edit.tpl
+++ b/includes/qcodo/_core/codegen/templates/db_orm/drafts/_qform_edit.tpl
@@ -1,7 +1,8 @@
 <template OverwriteFlag="true" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<%= __FORM_DRAFTS__ %>" TargetFileName="<%= QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName) %>_edit.php"/>
 <?php
 	// Load the Qcodo Development Framework
-	require(dirname(__FILE__) . '/../../includes/prepend.inc.php');
+	require(__DOCROOT__ . __PHP_ASSETS__ . '/_require_prepend.inc.php');
+
 
 	/**
 	 * This is a quick-and-dirty draft QForm object to do Create, Edit, and Delete functionality

--- a/includes/qcodo/_core/codegen/templates/db_orm/drafts/_qform_list.tpl
+++ b/includes/qcodo/_core/codegen/templates/db_orm/drafts/_qform_list.tpl
@@ -1,7 +1,8 @@
 <template OverwriteFlag="true" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<%= __FORM_DRAFTS__ %>" TargetFileName="<%= QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName) %>_list.php"/>
 <?php
 	// Load the Qcodo Development Framework
-	require(dirname(__FILE__) . '/../../includes/prepend.inc.php');
+	require(__DOCROOT__ . __PHP_ASSETS__ . '/_require_prepend.inc.php');
+
 
 	/**
 	 * This is a quick-and-dirty draft QForm object to do the List All functionality

--- a/www/drafts/index.php
+++ b/www/drafts/index.php
@@ -1,6 +1,6 @@
 <?php
 	// Include prepend.inc to load Qcodo
-	require(dirname(__FILE__) . '/../../includes/prepend.inc.php');
+	require(__DOCROOT__ . __PHP_ASSETS__ . '/_require_prepend.inc.php');
 
 	// Security check for ALLOW_REMOTE_ADMIN
 	// To allow access REGARDLESS of ALLOW_REMOTE_ADMIN, simply remove the line below


### PR DESCRIPTION
This allows the drafts to work correctly when the docroot is not in the same directory as includes
