### PR TITLE
Add missing optional clauses to templates 

### DIFF
--- a/includes/qcodo/_core/codegen/templates/db_orm/class_gen/index_load_array.tpl
+++ b/includes/qcodo/_core/codegen/templates/db_orm/class_gen/index_load_array.tpl
@@ -21,7 +21,8 @@
 <% if (count($objColumnArray) > 1) { %>
 					)
 <% } %><%-%>,
-					$objOptionalClauses);
+					$objOptionalClauses
+					);
 			} catch (QCallerException $objExc) {
 				$objExc->IncrementOffset();
 				throw $objExc;
@@ -36,7 +37,7 @@
 <% } %>
 		 * @return int
 		*/
-		public static function CountBy<%= $objCodeGen->ImplodeObjectArray('', '', '', 'PropertyName', $objColumnArray); %>(<%= $objCodeGen->ParameterListFromColumnArray($objColumnArray); %>) {
+		public static function CountBy<%= $objCodeGen->ImplodeObjectArray('', '', '', 'PropertyName', $objColumnArray); %>(<%= $objCodeGen->ParameterListFromColumnArray($objColumnArray); %>, $objOptionalClauses = null) {
 			// Call <%= $objTable->ClassName %>::QueryCount to perform the CountBy<%= $objCodeGen->ImplodeObjectArray('', '', '', 'PropertyName', $objColumnArray); %> query
 			return <%= $objTable->ClassName %>::QueryCount(
 <% if (count($objColumnArray) > 1) { %>
@@ -48,5 +49,6 @@
 <% if (count($objColumnArray) > 1) { %>
 				)
 <% } %>
+			, $objOptionalClauses
 			);
 		}

--- a/includes/qcodo/_core/codegen/templates/db_orm/class_gen/index_load_array_manytomany.tpl
+++ b/includes/qcodo/_core/codegen/templates/db_orm/class_gen/index_load_array_manytomany.tpl
@@ -24,8 +24,9 @@
 		 * @param <%= $objManyToManyReference->OppositeVariableType %> $<%= $objManyToManyReference->OppositeVariableName %>
 		 * @return int
 		*/
-		public static function CountBy<%= $objManyToManyReference->ObjectDescription %>($<%= $objManyToManyReference->OppositeVariableName %>) {
+		public static function CountBy<%= $objManyToManyReference->ObjectDescription %>($<%= $objManyToManyReference->OppositeVariableName %>, $objOptionalClauses = null) {
 			return <%= $objTable->ClassName %>::QueryCount(
-				QQ::Equal(QQN::<%= $objTable->ClassName %>()-><%= $objManyToManyReference->ObjectDescription %>-><%= $objManyToManyReference->OppositePropertyName %>, $<%= $objManyToManyReference->OppositeVariableName %>)
+				QQ::Equal(QQN::<%= $objTable->ClassName %>()-><%= $objManyToManyReference->ObjectDescription %>-><%= $objManyToManyReference->OppositePropertyName %>, $<%= $objManyToManyReference->OppositeVariableName %>),
+				$objOptionalClauses
 			);
 		}

--- a/includes/qcodo/_core/codegen/templates/db_orm/class_gen/index_load_single.tpl
+++ b/includes/qcodo/_core/codegen/templates/db_orm/class_gen/index_load_single.tpl
@@ -7,7 +7,7 @@
 <% } %>
 		 * @return <%= $objTable->ClassName %>
 		*/
-		public static function LoadBy<%= $objCodeGen->ImplodeObjectArray('', '', '', 'PropertyName', $objColumnArray); %>(<%= $objCodeGen->ParameterListFromColumnArray($objColumnArray); %>) {
+		public static function LoadBy<%= $objCodeGen->ImplodeObjectArray('', '', '', 'PropertyName', $objColumnArray); %>(<%= $objCodeGen->ParameterListFromColumnArray($objColumnArray); %>, $objOptionalClauses = null) {
 			return <%= $objTable->ClassName %>::QuerySingle(
 <% if (count($objColumnArray) > 1) { %>
 				QQ::AndCondition(
@@ -18,5 +18,6 @@
 <% if (count($objColumnArray) > 1) { %>
 				)
 <% } %>
+			, $objOptionalClauses
 			);
 		}


### PR DESCRIPTION
Some of the CountBy and LoadBy function templates were missing the ability to take in an optional clause which we find useful for expands.
