### PR TITLE
ob_clean() with no buffers

### DIFF
--- a/includes/qcodo/_core/framework/QApplicationBase.class.php
+++ b/includes/qcodo/_core/framework/QApplicationBase.class.php
@@ -684,7 +684,9 @@
 		 */
 		public static function Redirect($strLocation) {
 			// Clear the output buffer (if any)
-			ob_clean();
+			if( count(ob_list_handlers()) ) {
+				ob_clean();
+			}
 
 			if ((QApplication::$RequestMode == QRequestMode::Ajax) ||
 				(array_key_exists('Qform__FormCallType', $_POST) &&


### PR DESCRIPTION
Fixes a PHP Notice when calling clean with no output buffer active
