### PR TITLE
Feature to disable controls during AJAX actions

### DIFF
--- a/includes/qcodo/_core/qform/_actions.inc.php
+++ b/includes/qcodo/_core/qform/_actions.inc.php
@@ -146,7 +146,7 @@
 			$strToggleEnableControlIds = null;
 			if ($this->mixToggleEnableControls instanceof QControl) {
 				$strToggleEnableControlIds = $this->mixToggleEnableControls->ControlId;
-			} else if (gettype($this->mixToggleEnableControls) == 'array') {
+			} else if (is_array($this->mixToggleEnableControls)) {
 				$arrToggleEnableControlIds = array();
 				foreach ($this->mixToggleEnableControls as $objToggleEnableControl) {
 					$arrToggleEnableControlIds[] = $objToggleEnableControl->ControlId;

--- a/www/assets/js/_core/post.js
+++ b/www/assets/js/_core/post.js
@@ -92,7 +92,7 @@
 
 	qcodo.objAjaxWaitIcon = null;
 	qcodo.ajaxRequest = null;
-	qcodo.arrToggleEnableControls = [];
+	qcodo.arrToggleEnableControlIds = [];
 
 	qcodo.handleAjaxResponse = function(objEvent, objIframeResponse) {
 		var objRequest;
@@ -173,9 +173,9 @@
 			if (qcodo.objAjaxWaitIcon)
 				qcodo.objAjaxWaitIcon.style.display = 'none';
 
-			// Enable controls (if applicable)
-			for (var i = 0; i < qcodo.arrToggleEnableControls.length; i++) {
-				qcodo.arrToggleEnableControls[i].disabled = false;
+			// Toggle enabled/disabled controls (if applicable)
+			for (var i = 0; i < qcodo.arrToggleEnableControlIds.length; i++) {
+				qcodo.getWrapper(qcodo.arrToggleEnableControlIds[i]).toggleEnabled();
 			}
 
 			// If there are still AjaxEvents in the queue, go ahead and process/dequeue them
@@ -200,15 +200,18 @@
 					this.objAjaxWaitIcon.style.display = 'inline';
 			};
 
-			// Disable controls (if applicable)
-			var arrToggleEnableControlIds = strToggleEnableControlIds.split(',');
-			for (var i = 0; i < arrToggleEnableControlIds.length; i++) {
-				var objToggleEnableControl = document.getElementById(arrToggleEnableControlIds[i]);
-				if (objToggleEnableControl) {
-					this.arrToggleEnableControls.push(objToggleEnableControl);
-					objToggleEnableControl.disabled = true;
+			// Toggle enabled/disabled controls (if applicable)
+			if (strToggleEnableControlIds) {
+				this.arrToggleEnableControlIds = [];
+				var arrToggleEnableControlIds = strToggleEnableControlIds.split(',');
+				for (var i = 0; i < arrToggleEnableControlIds.length; i++) {
+					var objToggleEnableControl = document.getElementById(arrToggleEnableControlIds[i]);
+					if (objToggleEnableControl) {
+						this.arrToggleEnableControlIds.push(arrToggleEnableControlIds[i]);
+						this.getWrapper(arrToggleEnableControlIds[i]).toggleEnabled();
+					}
 				}
-			};			
+			};
 
 			var objForm = document.getElementById(strForm);
 			objForm.Qform__FormControl.value = strControl;


### PR DESCRIPTION
Please review and let me know if changes are needed. Thanks Mike!

QAjaxAction and QAjaxControlAction will now accept an optional
ToggleEnableControls parameter of either a single QControl or an array
of QControls to disable during the AJAX action processing. The
control(s) will be enabled again after the AJAX action completes.
